### PR TITLE
Semester manage and create modals modifications

### DIFF
--- a/src/components/settings/ManageSemestersModal.tsx
+++ b/src/components/settings/ManageSemestersModal.tsx
@@ -13,9 +13,10 @@ import {
   TouchableOpacity,
   View,
   Button,
+  Alert,
 } from "react-native";
 import { useState } from "react";
-import NewSemesterForm from "./NewSemesterForm";
+import NewSemesterModal from "./NewSemesterModal";
 
 interface ManageSemestersModalProps {
   visible: boolean;
@@ -43,38 +44,67 @@ const ManageSemestersModal: React.FC<ManageSemestersModalProps> = ({
       <View style={styles.modalBackground}>
         <View style={styles.modalContainer}>
           <Text style={styles.modalTitle}>Manage Semesters</Text>
+          <Text style={styles.modalSubtitle}>Active Semester: {selectedSemester.title}</Text>
 
           <ScrollView contentContainerStyle={styles.scrollContent}>
-            {semesters.map((semester) => (
-              <View key={semester.id} style={styles.semesterItem}>
-                <Text style={styles.semesterText}>{semester.title}</Text>
-                <Text style={styles.semesterDate}>{`Start: ${semester.start_date}`}</Text>
-                <Text style={styles.semesterDate}>{`End: ${semester.end_date}`}</Text>
+            {semesters.map((semester) => {
+              const isSelected = selectedSemester.id === semester.id;
 
-                <View style={styles.buttonRow}>
-                  <TouchableOpacity
-                    style={styles.selectButton}
-                    onPress={() => {
-                      selectedSemesterStateSetter(semester);
-                      saveSelectedSemester(semester);
-                      onClose();
-                    }}
-                  >
-                    <Text style={styles.buttonText}>Select</Text>
-                  </TouchableOpacity>
+              return (
+                <View key={semester.id} style={styles.semesterItem}>
+                  <Text style={styles.semesterText}>{semester.title}</Text>
+                  <Text style={styles.semesterDate}>{`Start: ${semester.start_date}`}</Text>
+                  <Text style={styles.semesterDate}>{`End: ${semester.end_date}`}</Text>
 
-                  <TouchableOpacity
-                    style={styles.deleteButton}
-                    onPress={() => {
-                      deleteSemester(db, semester.id);
-                      getSemesters(db, semestersStateSetter);
-                    }}
-                  >
-                    <Text style={styles.buttonText}>Delete</Text>
-                  </TouchableOpacity>
+                  <View style={styles.buttonRow}>
+                    <TouchableOpacity
+                      style={[
+                        styles.selectButton,
+                        isSelected && styles.disabledButton,
+                      ]}
+                      disabled={isSelected}
+                      onPress={() => {
+                        selectedSemesterStateSetter(semester);
+                        saveSelectedSemester(semester);
+                      }}
+                    >
+                      <Text style={styles.buttonText}>
+                        {isSelected ? "Active" : "Set Active"}</Text>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                      style={[
+                        styles.deleteButton,
+                      isSelected && styles.disabledButton,
+                      ]}
+                      disabled={isSelected}
+                      onPress={() => {
+                        Alert.alert(
+                          "Confirm Delete",
+                          "Are you sure you want to delete this semester? This will also delete all tasks associated with it.",
+                          [
+                            {
+                              text: "Cancel",
+                              style: "cancel",
+                            },
+                            {
+                              text: "Delete",
+                              style: "destructive",
+                              onPress: () => {
+                                deleteSemester(db, semester.id);
+                                getSemesters(db, semestersStateSetter);
+                              },
+                            },
+                          ]
+                        );
+                      }}
+                    >
+                      <Text style={styles.buttonText}>Delete</Text>
+                    </TouchableOpacity>
+                  </View>
                 </View>
-              </View>
-            ))}
+              )
+            })}
           </ScrollView>
 
           <View style={styles.bottomButtons}>
@@ -84,7 +114,7 @@ const ManageSemestersModal: React.FC<ManageSemestersModalProps> = ({
           </View>
         </View>
 
-        <NewSemesterForm
+        <NewSemesterModal
           visible={newSemesterModalVisible}
           onClose={() => setNewSemesterModalVisible(false)}
           db={db}
@@ -109,8 +139,14 @@ const styles = StyleSheet.create({
   modalTitle: {
     fontSize: 22,
     fontWeight: "600",
-    marginBottom: 20,
+    marginBottom: 10,
     textAlign: "center",
+  },
+  modalSubtitle: {
+    fontSize: 16,
+    fontWeight: "500",
+    textAlign: "center",
+    marginBottom: 20,
   },
   scrollContent: {
     paddingBottom: 20,
@@ -147,6 +183,9 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     paddingHorizontal: 12,
     borderRadius: 6,
+  },
+  disabledButton: {
+    opacity: 0.5,
   },
   buttonText: {
     color: "white",

--- a/src/components/settings/NewSemesterModal.tsx
+++ b/src/components/settings/NewSemesterModal.tsx
@@ -29,7 +29,7 @@ interface NewSemesterFormProps {
   >;
 }
 
-const NewSemesterForm: React.FC<NewSemesterFormProps> = ({
+const NewSemesterModal: React.FC<NewSemesterFormProps> = ({
   visible,
   onClose,
   db,
@@ -38,7 +38,11 @@ const NewSemesterForm: React.FC<NewSemesterFormProps> = ({
 }) => {
   const [title, setTitle] = useState("");
   const [startDate, setStartDate] = useState(new Date());
-  const [endDate, setEndDate] = useState(new Date());
+  const [endDate, setEndDate] = useState(() => {
+    const date = new Date();
+    date.setMonth(date.getMonth() + 4); // Default to 4 months from now
+    return date;
+  });
   const [showStartDatePicker, setShowStartDatePicker] = useState(false);
   const [showEndDatePicker, setShowEndDatePicker] = useState(false);
 
@@ -63,7 +67,6 @@ const NewSemesterForm: React.FC<NewSemesterFormProps> = ({
     await getSelectedSemester(selectedSemesterStateSetter);
     await getSemesters(db, semestersStateSetter);
     onClose();
-    alert("New semester created successfully!");
     setTitle("");
   };
 
@@ -173,4 +176,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default NewSemesterForm;
+export default NewSemesterModal;

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -9,11 +9,12 @@ import CalendarView from './CalendarView';
 import TasksView from './TasksView';
 import SettingsView from './SettingsView';
 import { useEffect, useState } from 'react';
-import NewSemesterForm from '../components/settings/NewSemesterForm';
+import NewSemesterForm from '../components/settings/NewSemesterModal';
 import Semester from '../types/Semester';
 
 // Reset database on app load (for testing) - will crash if db does not exist.
 //SQLite.deleteDatabaseSync('planit.db')
+console.log("Opening DB...");
 
 const db = SQLite.openDatabaseSync('planit.db'); // Open DB
 const Tab = createBottomTabNavigator(); // Create bottom nav bar

--- a/src/pages/SettingsView.tsx
+++ b/src/pages/SettingsView.tsx
@@ -1,7 +1,7 @@
 import * as SQLite from 'expo-sqlite';
 import React, { useState } from "react";
 import { View, Text, Button, StyleSheet } from "react-native";
-import NewSemesterForm from "../components/settings/NewSemesterForm";
+import NewSemesterForm from "../components/settings/NewSemesterModal";
 import Semester from '../types/Semester';
 import ManageSemestersModal from '../components/settings/ManageSemestersModal';
 


### PR DESCRIPTION
New semester modal date picker default date now 4 months from current date (makes choosing start date easier if it is after the current date). Manage semester modal now disables set active and delete buttons to current active semester. Sub title at top also displays current active semester. Modal doesn't close when selecting new semester. New semester form renamed to new semester modal.   Removed alert for creating new semester. Conformation menu for deleting a semester.